### PR TITLE
Add option to re-enable old email address parsing

### DIFF
--- a/src/Markdown/Markdown.cs
+++ b/src/Markdown/Markdown.cs
@@ -58,6 +58,7 @@ namespace HeyRed.MarkdownSharp
         public bool LinkEmails { get; set; } = true;
         public bool StrictBoldItalic { get; set; } = false;
         public bool AsteriskIntraWordEmphasis { get; set; } = false;
+        public bool EmailAddressMustBeSurroundedByAngleBrackets { get; set; } = false;
 
         /// <summary>
         /// Create a new Markdown instance using default options
@@ -87,6 +88,7 @@ namespace HeyRed.MarkdownSharp
             LinkEmails = options.LinkEmails;
             StrictBoldItalic = options.StrictBoldItalic;
             AsteriskIntraWordEmphasis = options.AsteriskIntraWordEmphasis;
+            EmailAddressMustBeSurroundedByAngleBrackets = options.EmailAddressMustBeSurroundedByAngleBrackets;
         }
 
         #endregion
@@ -1439,6 +1441,11 @@ namespace HeyRed.MarkdownSharp
                         \@
                         [-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+
                       )";
+                // Email addresses: <address@domain.foo> (to enable 
+                if (EmailAddressMustBeSurroundedByAngleBrackets)
+                {
+                    pattern = $"<{pattern}>";
+                }
                 text = Regex.Replace(text, pattern, new MatchEvaluator(EmailEvaluator), RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
             }
 

--- a/src/Markdown/Markdown.cs
+++ b/src/Markdown/Markdown.cs
@@ -58,7 +58,7 @@ namespace HeyRed.MarkdownSharp
         public bool LinkEmails { get; set; } = true;
         public bool StrictBoldItalic { get; set; } = false;
         public bool AsteriskIntraWordEmphasis { get; set; } = false;
-        public bool EmailAddressMustBeSurroundedByAngleBrackets { get; set; } = false;
+        public bool EmailAddressMustBeSurroundedByAngleBrackets { get; set; } = true;
 
         /// <summary>
         /// Create a new Markdown instance using default options
@@ -1441,7 +1441,7 @@ namespace HeyRed.MarkdownSharp
                         \@
                         [-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]+
                       )";
-                // Email addresses: <address@domain.foo> (to enable 
+                // Email addresses: <address@domain.foo> (to keep enable compatibility with https://code.google.com/archive/p/markdownsharp/)
                 if (EmailAddressMustBeSurroundedByAngleBrackets)
                 {
                     pattern = $"<{pattern}>";

--- a/src/Markdown/MarkdownOptions.cs
+++ b/src/Markdown/MarkdownOptions.cs
@@ -100,5 +100,11 @@ namespace HeyRed.MarkdownSharp
         /// this does nothing if StrictBoldItalic is false
         /// </summary>
         public bool AsteriskIntraWordEmphasis { get; set; }
+
+        /// <summary>
+        /// when true, email addresses are only turned into hyperlinks
+        /// when they are surrounded by angle brackets (&lt;address@domain.com&gt;)
+        /// </summary>
+        public bool EmailAddressMustBeSurroundedByAngleBrackets { get; set; }
     }
 }

--- a/src/Markdown/MarkdownOptions.cs
+++ b/src/Markdown/MarkdownOptions.cs
@@ -105,6 +105,6 @@ namespace HeyRed.MarkdownSharp
         /// when true, email addresses are only turned into hyperlinks
         /// when they are surrounded by angle brackets (&lt;address@domain.com&gt;)
         /// </summary>
-        public bool EmailAddressMustBeSurroundedByAngleBrackets { get; set; }
+        public bool EmailAddressMustBeSurroundedByAngleBrackets { get; set; } = true;
     }
 }

--- a/tests/MarkdownTests/LinkTests.cs
+++ b/tests/MarkdownTests/LinkTests.cs
@@ -155,5 +155,29 @@ namespace HeyRed.MarkdownSharpTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void EmailAddress()
+        {
+            string input = "Send an email to address@example.com for help";
+            string expected = "<p>Send an email to <a href=\".*\">.*</a> for help</p>";
+
+            string actual = _instance.Transform(input);
+
+            Assert.Matches(expected, actual);
+        }
+
+        [Fact]
+        public void EmailAddressWhenEmailMustBeSurroundedByAngleBrackets()
+        {
+            var options = new MarkdownOptions { EmailAddressMustBeSurroundedByAngleBrackets = true, LinkEmails = true };
+            var markdown = new Markdown(options);
+            string input = "this email address 'address@example.com' should not be encoded, but this email address '<address@example.com>' should";
+            string expected = "<p>this email address 'address@example.com' should not be encoded, but this email address '<a href=\".*\">.*</a>' should</p>";
+
+            string actual = markdown.Transform(input);
+
+            Assert.Matches(expected, actual);
+        }
     }
 }

--- a/tests/MarkdownTests/LinkTests.cs
+++ b/tests/MarkdownTests/LinkTests.cs
@@ -157,12 +157,29 @@ namespace HeyRed.MarkdownSharpTests
         }
 
         [Fact]
-        public void EmailAddress()
+        public void EmailAddressWhenLinkEmailsIsFalse()
         {
+            var options = new MarkdownOptions { EmailAddressMustBeSurroundedByAngleBrackets = false, LinkEmails = false };
+            var markdown = new Markdown(options);
+
+            string input = "Send an email to address@example.com or <address2@example.com> for help";
+            string expected = "<p>Send an email to address@example.com or <address2@example.com> for help</p>";
+
+            string actual = markdown.Transform(input);
+
+            Assert.Matches(expected, actual);
+        }
+
+        [Fact]
+        public void EmailAddressWhenEmailDoesNotNeedToBeSurroundedByAngleBrackets()
+        {
+            var options = new MarkdownOptions { EmailAddressMustBeSurroundedByAngleBrackets = false, LinkEmails = true };
+            var markdown = new Markdown(options);
+
             string input = "Send an email to address@example.com for help";
             string expected = "<p>Send an email to <a href=\".*\">.*</a> for help</p>";
 
-            string actual = _instance.Transform(input);
+            string actual = markdown.Transform(input);
 
             Assert.Matches(expected, actual);
         }

--- a/tests/MarkdownTests/MarkdownConstructorTests.cs
+++ b/tests/MarkdownTests/MarkdownConstructorTests.cs
@@ -1,0 +1,15 @@
+﻿using Xunit;
+using HeyRed.MarkdownSharp;
+
+namespace HeyRed.MarkdownSharpTests
+{
+    public class MarkdownConstructorTests
+    {
+        [Fact]
+        public void EmailAddressMustBeSurroundedByAngleBracketsDefaultsToTrue()
+        {
+            var markdown = new Markdown();
+            Assert.Equal(markdown.EmailAddressMustBeSurroundedByAngleBrackets, true);
+        }
+    }
+}

--- a/tests/MarkdownTests/MarkdownOptionsTests.cs
+++ b/tests/MarkdownTests/MarkdownOptionsTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using HeyRed.MarkdownSharp;
+
+namespace HeyRed.MarkdownSharpTests
+{
+    public class MarkdownOptionsTests
+    {
+        [Fact]
+        public void EmailAddressMustBeSurroundedByAngleBracketsDefaultsToTrue()
+        {
+            var markdownOptions = new MarkdownOptions();
+            Assert.Equal(markdownOptions.EmailAddressMustBeSurroundedByAngleBrackets, true);
+        }
+    }
+}


### PR DESCRIPTION
The old way only handled email addresses wrapped in angle brackets, ie <address@domain.foo> whereas it now allows emails without the angle brackets, ie address@domain.foo.

This PR adds an option (defaults to false) that allows the old behaviour.

Fixes hey-red/Mardown#75