### PR TITLE
Support for demoting header tags

### DIFF
--- a/src/Markdown/Markdown.cs
+++ b/src/Markdown/Markdown.cs
@@ -59,6 +59,7 @@ namespace HeyRed.MarkdownSharp
         public bool LinkEmailsWithoutAngleBrackets { get; set; } = false;
         public bool StrictBoldItalic { get; set; } = false;
         public bool AsteriskIntraWordEmphasis { get; set; } = false;
+        public int DemoteHeadersOffset { get; set; } = 0;
 
         /// <summary>
         /// Create a new Markdown instance using default options
@@ -89,6 +90,7 @@ namespace HeyRed.MarkdownSharp
             LinkEmailsWithoutAngleBrackets = options.LinkEmailsWithoutAngleBrackets;
             StrictBoldItalic = options.StrictBoldItalic;
             AsteriskIntraWordEmphasis = options.AsteriskIntraWordEmphasis;
+            DemoteHeadersOffset = options.DemoteHeadersOffset;
         }
 
         #endregion
@@ -1004,6 +1006,7 @@ namespace HeyRed.MarkdownSharp
         {
             string header = match.Groups[1].Value;
             int level = match.Groups[2].Value.StartsWith("=") ? 1 : 2;
+            level += DemoteHeadersOffset;
             return string.Format("<h{1}>{0}</h{1}>\n\n", RunSpanGamut(header), level);
         }
 
@@ -1011,6 +1014,7 @@ namespace HeyRed.MarkdownSharp
         {
             string header = match.Groups[2].Value;
             int level = match.Groups[1].Value.Length;
+            level += DemoteHeadersOffset;
             return string.Format("<h{1}>{0}</h{1}>\n\n", RunSpanGamut(header), level);
         }
 

--- a/src/Markdown/MarkdownOptions.cs
+++ b/src/Markdown/MarkdownOptions.cs
@@ -105,5 +105,10 @@ namespace HeyRed.MarkdownSharp
         /// when true, email addresses will be auto-linked without angle brackets
         /// </summary>
         public bool LinkEmailsWithoutAngleBrackets { get; set; }
+        
+        /// <summary>
+        /// Offsets the header tags by given value. For example when value is set to 2 the top level header will be rendered as <h3> instead of <h1>. This is useful to create semantically correct html documents when markdown output is embedded into a html which already contains headers.
+        /// </summary>
+        public int DemoteHeadersOffset { get; set; }
     }
 }

--- a/tests/MarkdownTests/BaseTests.cs
+++ b/tests/MarkdownTests/BaseTests.cs
@@ -188,5 +188,30 @@ namespace HeyRed.MarkdownSharpTests
 
             Assert.Equal(expected, actual);
         }
+        
+        
+        [Fact]
+        public void DemotingHeader1()
+        {
+            string input = "#Header 1\nHeader 1\n========";
+            string expected = "<h3>Header 1</h3>\n\n<h3>Header 1</h3>";
+
+            _instance.DemoteHeadersOffset = 2;
+            string actual = _instance.Transform(input);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void DemotingHeader2()
+        {
+            string input = "##Header 2\nHeader 2\n--------";
+            string expected = "<h4>Header 2</h4>\n\n<h4>Header 2</h4>";
+
+            _instance.DemoteHeadersOffset = 2;
+            string actual = _instance.Transform(input);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
Support for demoting header tags - it offsets the header tags by given value. For example when `DemoteHeadersOffset` is set to 2 the top level header will be rendered as `<h3>` instead of `<h1>`. 

This is useful to create semantically correct html documents when markdown output is later embedded into a html which already contains own headers (for example you can avoid duplicated h1 tags).
